### PR TITLE
Add frontend_base_url configuration for password reset emails

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -4,4 +4,4 @@ aurora_port: 5432
 aurora_database_name: jiki_test
 
 # Frontend URL for emails and CORS
-frontend_base_url: http://localhost:3000
+frontend_base_url: http://localhost:3060

--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -2,3 +2,6 @@
 aurora_endpoint: localhost
 aurora_port: 5432
 aurora_database_name: jiki_test
+
+# Frontend URL for emails and CORS
+frontend_base_url: http://localhost:3000

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -2,3 +2,6 @@
 aurora_endpoint: localhost
 aurora_port: 5432
 aurora_database_name: jiki_development
+
+# Frontend URL for emails and CORS
+frontend_base_url: http://localhost:3000

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -4,4 +4,4 @@ aurora_port: 5432
 aurora_database_name: jiki_development
 
 # Frontend URL for emails and CORS
-frontend_base_url: http://localhost:3000
+frontend_base_url: http://localhost:3060


### PR DESCRIPTION
## Summary

Adds `frontend_base_url` configuration value to support Devise password reset email integration. The API uses this to generate frontend URLs in reset emails.

## Changes

- ✅ Add `frontend_base_url: http://localhost:3000` to `settings/local.yml`
- ✅ Add `frontend_base_url: http://localhost:3000` to `settings/ci.yml`

## Usage

API accesses the configuration via:
```ruby
Jiki.config.frontend_base_url
```

This is used in the DeviseMailer to generate reset URLs like:
```
http://localhost:3000/auth/reset-password?token=abc123
```

## Configuration Pattern

Following the established Jiki config gem pattern:
- **Development/Test**: Loads from YAML files
- **Production**: Will load from DynamoDB

## Related PRs

- **API PR**: https://github.com/jiki-education/api/pull/36 - Implements password reset emails
- **Frontend**: See `DEVISE_EXTENSIONS_PLAN.md` for frontend implementation guide

## Testing

The API tests verify this configuration is used correctly:
```bash
cd ../api
bin/rails test test/mailers/devise_mailer_test.rb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)