### PR TITLE
Add Sidekiq Web UI credentials to secrets

### DIFF
--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -7,3 +7,7 @@ ses_smtp_username: "fake-ses-username"
 ses_smtp_password: "fake-ses-password"
 ses_smtp_address: "email-smtp.eu-west-2.amazonaws.com"
 ses_smtp_port: "587"
+
+# Sidekiq Web UI Credentials
+sidekiq_username: "admin"
+sidekiq_password: "admin"


### PR DESCRIPTION
## Summary
- Added `sidekiq_username` and `sidekiq_password` to `settings/secrets.yml`

## Details
These credentials are needed to protect the Sidekiq Web UI in the Rails API application. The credentials follow the same pattern as other service credentials in the secrets file (SES, Aurora, etc.).

**Default values for local development:**
- Username: `admin`
- Password: `admin`

For production, these values should be set appropriately in AWS Secrets Manager.

## Test plan
- [ ] Verify secrets.yml has the new fields
- [ ] Verify `Jiki.secrets.sidekiq_username` and `Jiki.secrets.sidekiq_password` are accessible after running `setup_jiki_config`
- [ ] Confirm Rails API can use these credentials for Sidekiq Web UI authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)