### PR TITLE
Add admin_base_url configuration for CORS

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -5,3 +5,6 @@ aurora_database_name: jiki_test
 
 # Frontend URL for emails and CORS
 frontend_base_url: http://localhost:3060
+
+# Admin URL for CORS
+admin_base_url: http://localhost:3062

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -5,3 +5,6 @@ aurora_database_name: jiki_development
 
 # Frontend URL for emails and CORS
 frontend_base_url: http://localhost:3060
+
+# Admin URL for CORS
+admin_base_url: http://localhost:3062


### PR DESCRIPTION
## Summary
- Added `admin_base_url: http://localhost:3062` to `settings/local.yml`
- Added `admin_base_url: http://localhost:3062` to `settings/ci.yml`

This enables the API to configure CORS for both the frontend and admin interfaces using centralized configuration values.

## Test plan
- [ ] Verify settings load correctly in development
- [ ] Verify settings load correctly in CI
- [ ] Verify API can access `Jiki.config.admin_base_url` after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)