### PR TITLE
Add Google API key to secrets configuration

### DIFF
--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -11,3 +11,6 @@ ses_smtp_port: "587"
 # Sidekiq Web UI Credentials
 sidekiq_username: "admin"
 sidekiq_password: "admin"
+
+# Gemini API
+google_api_key: "fake-google-api-key"


### PR DESCRIPTION
## Summary
- Add `google_api_key` to secrets configuration for Gemini API integration

## Changes
- **settings/secrets.yml**: Added `google_api_key` with placeholder value for local development

## Notes
- Placeholder value `fake-google-api-key` is used for local development
- Production value should be set in AWS Secrets Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)