### PR TITLE
Add S3 client helper method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Jiki.secrets.ses_smtp_port
 ### AWS Client Helpers
 ```ruby
 Jiki.dynamodb_client  # AWS DynamoDB client (for accessing config table)
+Jiki.s3_client        # AWS S3 client (for object storage operations)
 Jiki.ses_client       # AWS SES client (for email operations)
 ```
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       aws-sdk-secretsmanager (~> 1.0)
       mandate
       ostruct
+      rexml
       zeitwerk
 
 GEM
@@ -14,15 +15,23 @@ GEM
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1119.0)
-    aws-sdk-core (3.226.0)
+    aws-sdk-core (3.233.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
     aws-sdk-dynamodb (1.145.0)
       aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-kms (1.114.0)
+      aws-sdk-core (~> 3, >= 3.231.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.200.0)
+      aws-sdk-core (~> 3, >= 3.231.0)
+      aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sdk-secretsmanager (1.116.0)
       aws-sdk-core (~> 3, >= 3.225.0)
@@ -33,6 +42,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
+    bigdecimal (3.3.1)
     date (3.4.1)
     erb (5.0.2)
     io-console (0.8.1)
@@ -70,6 +80,7 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
+    rexml (3.4.4)
     rubocop (1.81.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -97,6 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   aws-sdk-sesv2
   bundler (~> 2.1)
   irb

--- a/jiki-config.gemspec
+++ b/jiki-config.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-secretsmanager', '~> 1.0'
   spec.add_dependency 'mandate'
   spec.add_dependency 'ostruct'
+  spec.add_dependency 'rexml'
   spec.add_dependency 'zeitwerk'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
@@ -36,5 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3'
 
   # Optional AWS service dependencies
+  spec.add_development_dependency 'aws-sdk-s3'
   spec.add_development_dependency 'aws-sdk-sesv2'
 end

--- a/lib/jiki.rb
+++ b/lib/jiki.rb
@@ -17,6 +17,15 @@ module Jiki
     Aws::DynamoDB::Client.new(JikiConfig::GenerateAwsSettings.())
   end
 
+  def self.s3_client
+    require 'aws-sdk-s3'
+    Aws::S3::Client.new(
+      JikiConfig::GenerateAwsSettings.().merge(
+        force_path_style: true
+      )
+    )
+  end
+
   def self.ses_client
     require 'aws-sdk-sesv2'
     Aws::SESV2::Client.new(JikiConfig::GenerateAwsSettings.())

--- a/test/jiki_config_test.rb
+++ b/test/jiki_config_test.rb
@@ -10,6 +10,11 @@ class JikiConfigTest < Minitest::Test
     assert_instance_of Aws::DynamoDB::Client, client
   end
 
+  def test_s3_client
+    s3_client = Jiki.s3_client
+    assert_equal "eu-west-2", s3_client.config.region
+  end
+
   def test_ses_client
     ses_client = Jiki.ses_client
     assert_equal "eu-west-2", ses_client.config.region


### PR DESCRIPTION
## Summary
- Added `Jiki.s3_client` helper method following the same pattern as exercism-config
- Provides easy access to an AWS S3 client configured with proper region and LocalStack compatibility

## Changes
- **lib/jiki.rb**: Added `s3_client` method with `force_path_style: true` for LocalStack support
- **jiki-config.gemspec**: Added `rexml` as a dependency (lightweight XML parser built into Ruby's standard library) and `aws-sdk-s3` as development dependency
- **AGENTS.md**: Updated documentation to include the new S3 client helper
- **test/jiki_config_test.rb**: Added test to verify S3 client configuration

## Implementation Details
- Uses `rexml` for XML parsing (built into Ruby stdlib, no native extensions required)
- Follows the exact same pattern as exercism-config's `s3_client` implementation
- Includes `force_path_style: true` for compatibility with LocalStack in development/testing

## Test Results
All tests pass:
```
8 runs, 17 assertions, 0 failures, 0 errors, 0 skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)