### PR TITLE
Add ElevenLabs API key to secrets configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Jiki.secrets.ses_smtp_username
 Jiki.secrets.ses_smtp_password
 Jiki.secrets.ses_smtp_address
 Jiki.secrets.ses_smtp_port
+
+# API Keys
+Jiki.secrets.google_api_key      # Google Gemini API key
+Jiki.secrets.elevenlabs_api_key  # ElevenLabs API key
 ```
 
 ## Helper Methods

--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -14,3 +14,6 @@ sidekiq_password: "admin"
 
 # Gemini API
 google_api_key: "fake-google-api-key"
+
+# ElevenLabs API
+elevenlabs_api_key: "fake-elevenlabs-api-key"


### PR DESCRIPTION
## Summary
- Added `elevenlabs_api_key` to secrets configuration
- Updated AGENTS.md documentation to include the new secret
- Organized API keys section in documentation

## Changes
- **settings/secrets.yml**: Added ElevenLabs API key with dummy value for local development
- **AGENTS.md**: Added API Keys section documenting both Google and ElevenLabs API keys

## Usage
After merging, access the secret via:
```ruby
Jiki.secrets.elevenlabs_api_key
```

For local development, run `bundle exec setup_jiki_config` to reload secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)