### PR TITLE
Add S3 video production bucket configuration

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -8,3 +8,6 @@ frontend_base_url: http://localhost:3060
 
 # Admin URL for CORS
 admin_base_url: http://localhost:3062
+
+# S3 Buckets
+s3_bucket_video_production: test-bucket

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -14,3 +14,6 @@ spi_base_url: http://localhost:3061/spi/
 
 # LLM Proxy URL for AI translation services
 llm_proxy_url: http://localhost:3064/exec
+
+# S3 Buckets
+s3_bucket_video_production: jiki-videos-dev


### PR DESCRIPTION
## Summary
- Add `s3_bucket_video_production` configuration key to local and CI settings
- Sets up bucket names for storing video content in different environments

## Changes
- **settings/local.yml**: Added `s3_bucket_video_production: jiki-videos-dev` for local development
- **settings/ci.yml**: Added `s3_bucket_video_production: test-bucket` for CI testing

## Test plan
- [ ] Verify configuration loads correctly in local environment
- [ ] Verify configuration loads correctly in CI environment
- [ ] Test video upload/storage functionality with new bucket configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)