### PR TITLE
Add HMAC secret for assistant conversation verification

### DIFF
--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -20,3 +20,6 @@ elevenlabs_api_key: "fake-elevenlabs-api-key"
 
 # HeyGen API
 heygen_api_key: "fake-heygen-api-key"
+
+# HMAC Secret for Assistant Conversations
+hmac_secret: "dfabe5956e8dfadfdd925438bd8aa5269563f378362967cd7fb8963a5f8a5cb6"


### PR DESCRIPTION
## Summary
- Add `hmac_secret` to `settings/secrets.yml` for cryptographic signing of assistant messages

## Context
This secret will be used by:
1. **Rails API** (`Jiki.secrets.hmac_secret`) - To verify HMAC signatures on incoming assistant messages
2. **Cloudflare Workers LLM proxy** (`env.HMAC_SECRET`) - To sign assistant responses before sending to the API

## Security
The HMAC signature prevents users from forging fake LLM responses by ensuring message authenticity through cryptographic verification.

## Signature Format
```
payload = "#{user_id}:#{context_type}:#{context_identifier}:#{assistant_message}:#{timestamp}"
signature = HMAC-SHA256(payload, hmac_secret)
```

## Related PR
- Rails API implementation: Will be created next

🤖 Generated with [Claude Code](https://claude.com/claude-code)