### PR TITLE
Add ses_region configuration for AWS SES

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -35,3 +35,4 @@ support_email: hello@jiki.io
 ses_mail_configuration_set: test-mail-config
 ses_marketing_configuration_set: test-marketing-config
 ses_notifications_configuration_set: test-notifications-config
+ses_region: eu-west-1

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -38,3 +38,4 @@ support_email: hello@jiki.io
 ses_mail_configuration_set: jiki-mail-local
 ses_marketing_configuration_set: jiki-marketing-local
 ses_notifications_configuration_set: jiki-notifications-local
+ses_region: eu-west-1


### PR DESCRIPTION
## Summary

Adds `ses_region: eu-west-1` to local.yml and ci.yml config files.

## Why

The API requires this config value for ActionMailer's SESV2 delivery method (see jiki-education/api#136).

## Changes

- `settings/local.yml` - Added ses_region: eu-west-1
- `settings/ci.yml` - Added ses_region: eu-west-1

## Region

Using `eu-west-1` to match the Terraform AWS region default (terraform/aws/variables.tf).

## Deployment

This should be deployed before API PR #136 is merged/deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)