### PR TITLE
Sync config settings with terraform and API usage

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -12,9 +12,6 @@ admin_base_url: http://localhost:3062
 # SPI (Service Provider Interface) base URL for callbacks
 spi_base_url: http://local.jiki.io:3060/spi
 
-# S3 Buckets
-s3_bucket_video_production: test-bucket
-
 # Cloudflare R2 (test values)
 r2_account_id: "test-account-id"
 r2_endpoint: "http://localhost:4566"
@@ -39,3 +36,9 @@ ses_mail_configuration_set: test-mail-config
 ses_marketing_configuration_set: test-marketing-config
 ses_notifications_configuration_set: test-notifications-config
 ses_region: eu-west-1
+
+# LLM Proxy URL for AI translation services
+llm_proxy_url: http://localhost:3064/exec
+
+# Sentry Error Tracking (disabled in test)
+sentry_dsn: ""

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -15,9 +15,6 @@ spi_base_url: http://local.jiki.io:3060/spi
 # LLM Proxy URL for AI translation services
 llm_proxy_url: http://localhost:3064/exec
 
-# S3 Buckets
-s3_bucket_video_production: jiki-videos-dev
-
 # Cloudflare R2 (uses LocalStack in dev)
 r2_account_id: "0a0e6f92decf825364b860e2286ceebf"
 r2_endpoint: "http://localhost:4566"
@@ -42,3 +39,6 @@ ses_mail_configuration_set: jiki-mail-local
 ses_marketing_configuration_set: jiki-marketing-local
 ses_notifications_configuration_set: jiki-notifications-local
 ses_region: eu-west-1
+
+# Sentry Error Tracking (disabled in development)
+sentry_dsn: ""

--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -32,3 +32,9 @@ r2_secret_access_key: "fake-r2-secret-access-key"
 # Google OAuth Credentials
 google_oauth_client_id: "fake-google-oauth-client-id"
 google_oauth_client_secret: "fake-google-oauth-client-secret"
+
+# Rails secret key base (required in production)
+secret_key_base: "dev-secret-key-base-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Discourse SSO Secret
+discourse_sso_secret: "fake-discourse-sso-secret"


### PR DESCRIPTION
## Summary
- Added `sentry_dsn` to local.yml and ci.yml (was in terraform but missing from dev/test configs)
- Added `llm_proxy_url` to ci.yml (was in local.yml but missing from ci)
- Added `secret_key_base` and `discourse_sso_secret` to secrets.yml (used by API but were missing)
- Removed `s3_bucket_video_production` from local.yml and ci.yml (removed from terraform in #15)

## Test plan
- [ ] Verify API can read all config keys in development: `Jiki.config.sentry_dsn`, `Jiki.secrets.discourse_sso_secret`, `Jiki.secrets.secret_key_base`
- [ ] Run API test suite to ensure no missing config errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)