### PR TITLE
Rename Stripe price keys for annual billing

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -22,8 +22,8 @@ uploads_host: ""
 
 # Stripe Configuration (test mode)
 stripe_publishable_key: pk_test_fake_publishable_key
-stripe_premium_price_id: price_fake_premium
-stripe_max_price_id: price_fake_max
+stripe_premium_monthly_price_id: price_fake_premium_monthly
+stripe_premium_annual_price_id: price_fake_premium_annual
 
 # Email Configuration
 mail_from_email: hello@mail.jiki.io

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -25,8 +25,8 @@ uploads_host: "http://localhost:4566/uploads"
 
 # Stripe Configuration
 stripe_publishable_key: pk_test_51SPygTEvAkEDKF4oICBUOrPTFQuMgOwt9gHiP6LKggy7oFRPf56stByJMcM1z9ssTZRIMQSEDdnAXRrDrgqiDg6R00cD0VsQWQ
-stripe_premium_price_id: "price_1SPyjBEvAkEDKF4o2OAJy7Ir"
-stripe_max_price_id: "price_1SPyjcEvAkEDKF4oWbwiWVZh"
+stripe_premium_monthly_price_id: "price_1T2EPNEvAkEDKF4oJwWzt5L9"
+stripe_premium_annual_price_id: "price_1T2EQAEvAkEDKF4oDXXZgHhv"
 
 # Email Configuration
 mail_from_email: hello@mail.jiki.io


### PR DESCRIPTION
## Summary
- Renames `stripe_premium_price_id` → `stripe_premium_monthly_price_id`
- Renames `stripe_max_price_id` → `stripe_premium_annual_price_id`
- Updates both `local.yml` and `ci.yml`

Companion to jiki-education/api#286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)