### PR TITLE
Add PostHog config keys

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -42,3 +42,7 @@ llm_proxy_url: http://localhost:3064/exec
 
 # Sentry Error Tracking (disabled in test)
 sentry_dsn: ""
+
+# PostHog Analytics (no-op in non-production)
+posthog_host: "https://eu.i.posthog.com"
+posthog_api_key: "phc_fake_posthog_api_key"

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -42,3 +42,7 @@ ses_region: eu-west-1
 
 # Sentry Error Tracking (disabled in development)
 sentry_dsn: ""
+
+# PostHog Analytics (no-op in non-production)
+posthog_host: "https://eu.i.posthog.com"
+posthog_api_key: "phc_fake_posthog_api_key"


### PR DESCRIPTION
## Summary
- Adds `posthog_host` and `posthog_api_key` to `local.yml` and `ci.yml`
- Both use a fake key (`phc_fake_posthog_api_key`); real key will be supplied via production config
- App-side will gate event sending on `Rails.env.production?` so non-prod is a no-op regardless

## Test plan
- [ ] Bundle the gem locally in the API repo and confirm `Jiki.config.posthog_host` / `Jiki.config.posthog_api_key` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)