### PR TITLE
Pin localstack image to v3 to fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       aws:
-        image: "localstack/localstack"
+        image: "localstack/localstack:3"
         ports:
           - 4566
 


### PR DESCRIPTION
## Summary
- The `localstack/localstack:latest` image (2026.5.0.dev158, built 2026-05-17) now requires `LOCALSTACK_AUTH_TOKEN` and exits with code 55 on startup, failing the `aws` service container before tests run.
- Pin to `localstack/localstack:3`, which still works without a license.

## Test plan
- [ ] CI `test` job initializes the localstack container successfully and runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)