### PR TITLE
Add Turnstile keys for bot protection

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -20,6 +20,9 @@ r2_bucket_uploads: "test-uploads"
 assets_cdn_url: "https://test-assets.example.com"
 uploads_host: ""
 
+# Cloudflare Turnstile (bot protection)
+turnstile_site_key: "1x00000000000000000000AA"
+
 # Stripe Configuration (test mode)
 stripe_publishable_key: pk_test_fake_publishable_key
 stripe_premium_monthly_price_id: price_fake_premium_monthly

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -23,6 +23,10 @@ r2_bucket_uploads: "uploads"
 assets_cdn_url: "https://assets.jiki.io"
 uploads_host: "http://localhost:3065/uploads"
 
+# Cloudflare Turnstile (bot protection)
+# Dev uses Cloudflare's documented "always passes, visible" test site key.
+turnstile_site_key: "1x00000000000000000000AA"
+
 # Stripe Configuration
 stripe_publishable_key: pk_test_51SPygTEvAkEDKF4oICBUOrPTFQuMgOwt9gHiP6LKggy7oFRPf56stByJMcM1z9ssTZRIMQSEDdnAXRrDrgqiDg6R00cD0VsQWQ
 stripe_premium_monthly_price_id: "price_1T2EPNEvAkEDKF4oJwWzt5L9"

--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -38,3 +38,7 @@ secret_key_base: "dev-secret-key-base-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Discourse SSO Secret
 discourse_sso_secret: "fake-discourse-sso-secret"
+
+# Cloudflare Turnstile (bot protection)
+# Dev/test uses Cloudflare's documented "always passes" test secret key.
+turnstile_secret_key: "1x0000000000000000000000000000000AA"


### PR DESCRIPTION
## Summary
- Adds `turnstile_secret_key` to `Jiki.secrets` and `turnstile_site_key` to `Jiki.config`.
- Dev/test/CI use Cloudflare's documented test keys (`1x...AA` always-passes pair).
- Production values must be populated manually: secret into AWS Secrets Manager `config` blob, site key wherever public config is sourced for prod.

## Why
Paired with https://github.com/jiki-education/api/pull/402 which adds invisible Cloudflare Turnstile verification on signup, login, password-reset, and the assistant-chat token endpoint.

## Test plan
- [ ] CI green
- [ ] Verify `Jiki.secrets.turnstile_secret_key` resolves locally after merge
- [ ] Populate prod `turnstile_secret_key` in AWS Secrets Manager `config` blob before API PR is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)