### PR TITLE
Add Exercism OAuth keys

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -43,6 +43,9 @@ ses_region: eu-west-1
 # LLM Proxy URL for AI translation services
 llm_proxy_url: http://localhost:3064/exec
 
+# Exercism (OAuth sign-in provider)
+exercism_base_url: http://local.exercism.io:3020
+
 # Sentry Error Tracking (disabled in test)
 sentry_dsn: ""
 

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -15,6 +15,9 @@ spi_base_url: http://local.jiki.io:3060/spi
 # LLM Proxy URL for AI translation services
 llm_proxy_url: http://localhost:3064/exec
 
+# Exercism (OAuth sign-in provider)
+exercism_base_url: http://local.exercism.io:3020
+
 # Cloudflare R2 (uses LocalStack in dev)
 r2_account_id: "0a0e6f92decf825364b860e2286ceebf"
 r2_endpoint: "http://localhost:3065"

--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -33,6 +33,10 @@ r2_secret_access_key: "fake-r2-secret-access-key"
 google_oauth_client_id: "fake-google-oauth-client-id"
 google_oauth_client_secret: "fake-google-oauth-client-secret"
 
+# Exercism OAuth Credentials
+exercism_oauth_client_id: "fake-exercism-oauth-client-id"
+exercism_oauth_client_secret: "fake-exercism-oauth-client-secret"
+
 # Rails secret key base (required in production)
 secret_key_base: "dev-secret-key-base-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 


### PR DESCRIPTION
## Summary
Adds the config/secret keys needed for the "Sign in with Exercism" OAuth flow ([Jiki API integration with exercism/website#9166](https://github.com/exercism/website/pull/9166)):

- `exercism_base_url` (config) — Exercism host for the `/oauth/token` and `/api/oauth/userinfo` endpoints. Dev/CI point at `http://local.exercism.io:3020`.
- `exercism_oauth_client_id` / `exercism_oauth_client_secret` (secrets) — the Doorkeeper application credentials. Fake values for dev/test.

## Production setup (post-merge)
- Add `exercism_base_url` (`https://exercism.org`) to the DynamoDB config table.
- Add the real client id/secret (from Exercism's production `Doorkeeper::Application`) to AWS Secrets Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)