### PR TITLE
Disable default SDK checksums for the R2 client

### DIFF
--- a/lib/jiki.rb
+++ b/lib/jiki.rb
@@ -46,13 +46,21 @@ module Jiki
         secret_access_key: secrets.r2_secret_access_key,
         endpoint: "https://#{config.r2_account_id}.r2.cloudflarestorage.com",
         region: 'auto',
-        force_path_style: true
+        force_path_style: true,
+        # R2 doesn't support the SDK's default automatic CRC32 checksums
+        # ("You can only specify one non-default checksum at a time"),
+        # so only calculate checksums when strictly required.
+        request_checksum_calculation: 'when_required',
+        response_checksum_validation: 'when_required'
       )
     else
-      # Use LocalStack S3 for R2 in development
+      # Use LocalStack S3 for R2 in development.
+      # Keep checksum behaviour consistent with the production R2 client.
       Aws::S3::Client.new(
         JikiConfig::GenerateAwsSettings.().merge(
-          force_path_style: true
+          force_path_style: true,
+          request_checksum_calculation: 'when_required',
+          response_checksum_validation: 'when_required'
         )
       )
     end

--- a/test/jiki_config_test.rb
+++ b/test/jiki_config_test.rb
@@ -19,4 +19,13 @@ class JikiConfigTest < Minitest::Test
     ses_client = Jiki.ses_client
     assert_equal "eu-west-1", ses_client.config.region
   end
+
+  def test_r2_client_disables_default_checksums
+    Jiki.stubs(:secrets).returns(stub(r2_access_key_id: "key", r2_secret_access_key: "secret"))
+    Jiki.stubs(:config).returns(stub(r2_account_id: "account-id"))
+
+    r2_client = Jiki.r2_client
+    assert_equal "when_required", r2_client.config.request_checksum_calculation
+    assert_equal "when_required", r2_client.config.response_checksum_validation
+  end
 end


### PR DESCRIPTION
Fixes jiki-education/api#409

## Summary
- aws-sdk-s3 >= 1.178 calculates CRC32 request checksums by default (`request_checksum_calculation: "when_supported"`). Cloudflare R2's S3 compatibility layer rejects these requests with `You can only specify one non-default checksum at a time. (Aws::S3::Errors::InvalidRequest)`, which is breaking all production R2 uploads from the API (the api repo is on aws-sdk-s3 1.224.0).
- Sets `request_checksum_calculation` and `response_checksum_validation` to `"when_required"` on `Jiki.r2_client`, so checksums are only sent when an operation strictly requires them.
- Applied to both the production R2 client and the LocalStack dev/test client so behaviour is consistent across environments.
- Adds a test asserting the R2 client is configured with these options.

Once merged, the api repo needs a `bundle update jiki-config` to pick up the new revision.

## Test plan
- [x] `bundle exec rake test` — 9 runs, 0 failures
- [ ] After api's Gemfile.lock is bumped: retry the failing Sentry job (R2 image upload) in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)