### PR TITLE
Add skylight_key secret

### DIFF
--- a/settings/secrets.yml
+++ b/settings/secrets.yml
@@ -46,3 +46,6 @@ discourse_sso_secret: "fake-discourse-sso-secret"
 # Cloudflare Turnstile (bot protection)
 # Dev/test uses Cloudflare's documented "always passes" test secret key.
 turnstile_secret_key: "1x0000000000000000000000000000000AA"
+
+# Skylight APM token (empty in dev/test; real token via Secrets Manager in production)
+skylight_key: ""


### PR DESCRIPTION
Adds a `skylight_key` secret for the Skylight APM agent being introduced in the API (jiki-education/api#TBD).

- Empty placeholder in dev/test, so the Skylight agent stays inert locally.
- Production value must be set in AWS Secrets Manager (the OSS dashboard token).

Should merge **before** the API change so `bundle update jiki-config` picks up the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)