### PR TITLE
Add s3_active_storage_bucket and s3_active_storage_region

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -20,6 +20,10 @@ r2_bucket_uploads: "test-uploads"
 assets_cdn_url: "https://test-assets.example.com"
 uploads_host: ""
 
+# S3 Active Storage (exercise submission files; test values)
+s3_active_storage_bucket: "test-active-storage"
+s3_active_storage_region: "eu-west-1"
+
 # Cloudflare Turnstile (bot protection)
 turnstile_site_key: "1x00000000000000000000AA"
 

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -26,6 +26,10 @@ r2_bucket_uploads: "uploads"
 assets_cdn_url: "https://assets.jiki.io"
 uploads_host: "http://localhost:3065/uploads"
 
+# S3 Active Storage (exercise submission files; uses LocalStack in dev)
+s3_active_storage_bucket: "active-storage"
+s3_active_storage_region: "eu-west-1"
+
 # Cloudflare Turnstile (bot protection)
 # Dev uses Cloudflare's documented "always passes, visible" test site key.
 turnstile_site_key: "1x00000000000000000000AA"


### PR DESCRIPTION
Exercise submission files are moving from R2 to S3 in the API (R2 PUTs from ECS are a cross-cloud round-trip — Skylight shows ~250ms per upload, ~83% of the create request). This adds the config keys the API's `amazon` Active Storage service needs.

- `settings/local.yml` — dev values (LocalStack `active-storage` bucket)
- `settings/ci.yml` — CI/test values

Production `s3_active_storage_bucket` / `s3_active_storage_region` are populated in DynamoDB via Terraform.

Pairs with the API PR that switches submission files to the S3 service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)