### PR TITLE
Add api_base_url setting

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -6,6 +6,9 @@ aurora_database_name: jiki_test
 # Frontend URL for emails and CORS
 frontend_base_url: http://localhost:3060
 
+# API's own public base URL (used for one-click unsubscribe links in emails)
+api_base_url: http://localhost:3060
+
 # Admin URL for CORS
 admin_base_url: http://localhost:3062
 

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -6,6 +6,9 @@ aurora_database_name: jiki_development
 # Frontend URL for emails and CORS
 frontend_base_url: http://local.jiki.io:3061
 
+# API's own public base URL (used for one-click unsubscribe links in emails)
+api_base_url: http://local.jiki.io:3060
+
 # Admin URL for CORS
 admin_base_url: http://local.jiki.io:3062
 


### PR DESCRIPTION
Adds an `api_base_url` config value (the API's own public base URL).

Needed by jiki/api to build RFC 8058 one-click unsubscribe links in emails — the `List-Unsubscribe` header must POST to the API's `/auth/unsubscribe/:token` endpoint, not the frontend page, so the mailer needs an absolute URL to the API.

- `local.yml` → `http://local.jiki.io:3060`
- `ci.yml` → `http://localhost:3060`

**Production:** the `api_base_url` key must also be added to the production config (DynamoDB) before the API change deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)